### PR TITLE
いいね数のランキング機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "mixin/mixin";
 @import "posts/index";
 @import "posts/show";
+@import "posts/side-bar";
 @import "shared/posts-box";
 @import "shared/search";
 @import "users/show";

--- a/app/assets/stylesheets/posts/_index.scss
+++ b/app/assets/stylesheets/posts/_index.scss
@@ -1,7 +1,10 @@
 .posts {
   width: 70%;
-  margin: 80px auto;
+  margin: 80px;
   padding: 50px 0;
+  box-shadow: 0 2px 6px #c1ced7;
+  background-color: white;
+  border-radius: 10px;
   h2 {
   margin-bottom: 30px;
   text-align: center;

--- a/app/assets/stylesheets/posts/_side-bar.scss
+++ b/app/assets/stylesheets/posts/_side-bar.scss
@@ -1,0 +1,28 @@
+.side-bar {
+  width: 20%;
+  padding: 50px 10px 29px 0;
+  margin-right: 20px;
+  float: right;
+  box-shadow: 0 2px 6px #c1ced7;
+  background-color: white;
+  border-radius: 10px;
+
+  &__title {
+    text-align: center;
+    h2 {
+      font-size: 20px;
+      font-weight: bold;
+    }
+  }
+
+  &__box {
+    text-align: center;
+    a {
+      color: black;
+    }
+  }
+}
+
+.rank-img {
+  margin: 10px 0;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,6 +3,7 @@ class PostsController < ApplicationController
   
   def index
     @posts = Post.includes(:user).order('created_at DESC')
+    @all_ranks = Post.find(Like.group(:post_id).order('count(post_id) desc').limit(5).pluck(:post_id))
   end
 
   def new

--- a/app/views/posts/_side-bar.html.haml
+++ b/app/views/posts/_side-bar.html.haml
@@ -1,0 +1,14 @@
+.side-bar
+  .side-bar__title
+    %h2いいね数ランキング
+  .side-bar__box
+    - @all_ranks.each_with_index do |post, i|
+      %p
+        = link_to post_path(post.id) do
+          = i + 1
+          位
+          いいね数
+          = post.likes_count
+          %p= post.name
+          = link_to post_path(post.id) do
+            = image_tag(post.image.url, size: '110x110', class: "rank-img")

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -1,3 +1,4 @@
+= render "side-bar"
 .posts
   %h2投稿一覧
   = render "shared/posts-box"


### PR DESCRIPTION
# What
投稿一覧(posts/index.htnl.haml)にていいね数が多い順にランキング形式で表示できるようにした。

# Why
ランキング形式で表示することで、どのアイテムが人気か目安となるため。