### PR TITLE
ユーザーのその他の投稿確認の実装 その他修正

### DIFF
--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -3,7 +3,7 @@
 
 
 .row {
-  margin-top: 80px;
+  padding-top: 80px;
   text-align: center;
   color: #57575f;
   font-size: 30px;

--- a/app/assets/stylesheets/posts/_side-bar.scss
+++ b/app/assets/stylesheets/posts/_side-bar.scss
@@ -1,3 +1,4 @@
+// side-bar1
 .side-bar {
   width: 25%;
   padding: 50px 10px 29px 0;
@@ -8,6 +9,8 @@
 
   &__title {
     text-align: center;
+    font-size: 20px;
+    font-weight: bold;
     h2 {
       font-size: 20px;
       font-weight: bold;
@@ -20,8 +23,14 @@
       color: black;
     }
   }
+  &__box2 {
+    text-align: center;
+    p {
+      color: black;
+    }
+  }
 }
 
-.rank-img {
+.side-img {
   margin: 10px 0;
 }

--- a/app/assets/stylesheets/shared/_posts-box.scss
+++ b/app/assets/stylesheets/shared/_posts-box.scss
@@ -36,6 +36,9 @@
       padding: 0 25px;
       font-size: 14px;
       float: left;
+      a {
+        color: black;
+      }
     }
 
     &__like {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -28,8 +28,10 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
+    @user = User.find_by(id: @post.user_id)
+    @posts = @user.posts.page(params[:page]).order('created_at DESC')
     @comments = @post.comments.includes(:user)
-    @comment = Comment.new
+    @comment = Comment.new 
   end
 
   def edit
@@ -44,6 +46,7 @@ class PostsController < ApplicationController
   def search
     @posts = Post.search(params[:search])
     @posts_length = @posts.length
+    @all_ranks = Post.find(Like.group(:post_id).order('count(post_id) desc').limit(5).pluck(:post_id))
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,15 +1,14 @@
 class UsersController < ApplicationController
-  # before_action :authenticate_user!, only: [:show]
-  before_action :set_user
+  # before_action :set_user
 
   def index; end
 
   def show
-    @user = User.find_by(id: params[:id])
+    @user = User.find(params[:id])
     @posts = @user.posts.page(params[:page]).order('created_at DESC')
   end
 
-  def set_user
-    @user = User.find(params[:id])
-  end
+  # def set_user
+  #   @user = User.find(params[:id])
+  # end
 end

--- a/app/views/posts/_side-bar.html.haml
+++ b/app/views/posts/_side-bar.html.haml
@@ -10,5 +10,4 @@
           いいね数
           = post.likes_count
           %p= post.name
-          = link_to post_path(post.id) do
-            = image_tag(post.image.url, size: '200x200', class: "rank-img")
+          = image_tag(post.image.url, size: '200x200', class: "side-img")

--- a/app/views/posts/_side-bar2.html.haml
+++ b/app/views/posts/_side-bar2.html.haml
@@ -1,0 +1,8 @@
+.side-bar
+  .side-bar__title
+    = @post.user.nickname + "さんのその他の投稿"
+  .side-bar__box2
+    - @posts.each do |post|
+      = link_to post_path(post.id) do
+        %p= post.name
+        = image_tag(post.image.url, size: '200x200', class: "side-img")

--- a/app/views/posts/search.html.haml
+++ b/app/views/posts/search.html.haml
@@ -1,3 +1,4 @@
+= render "side-bar"
 .posts
   %h2= "検索結果：#{@posts_length}件"
   = render "shared/posts-box"

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,3 +1,4 @@
+= render "side-bar2"
 .post__show  
   .post__show__header
     .post__show__header__name

--- a/app/views/shared/_posts-box.html.haml
+++ b/app/views/shared/_posts-box.html.haml
@@ -8,7 +8,8 @@
       .posts__list__box__content
         = post.content
       .posts__list__box__user
-        = post.user.nickname
+        = link_to user_path(post.user) do
+          = post.user.nickname
       .posts__list__box__like
         %div{id: "likes_buttons_#{post.id}"}
           = render partial: 'likes/like', locals: { post: post, likes: @likes}


### PR DESCRIPTION
# What
投稿詳細ページに遷移後、投稿したユーザーのその他の投稿が確認できるようにした。
また、本プルリクエスト にて以下の修正を行なった。
・検索を行なった結果のページにて、横にいいね数ランキングを表示できるようにした。
・ログイン、新規登録、新規投稿及び編集のフォーム画面の修正
・投稿一覧にて投稿したユーザーをクリックするとユーザー詳細ページに遷移できるようにした。

# Why
ユーザービリティを向上させるため。