### PR TITLE
ページネーションの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@
 @import "posts/index";
 @import "posts/show";
 @import "posts/side-bar";
+@import "shared/paginate";
 @import "shared/posts-box";
 @import "shared/search";
 @import "users/show";

--- a/app/assets/stylesheets/mixin/_mixin.scss
+++ b/app/assets/stylesheets/mixin/_mixin.scss
@@ -4,7 +4,7 @@
 }
 
 @mixin product-box {
-  height: 380px;
+  height: 335px;
   width: 300px;
   margin: 40px 10px 0 12px;
   padding: 20px 0;

--- a/app/assets/stylesheets/shared/_paginate.scss
+++ b/app/assets/stylesheets/shared/_paginate.scss
@@ -1,0 +1,38 @@
+// .pagination {
+//   text-align: center;
+//   margin-top: 50px;
+//   color: blue;
+// }
+
+
+
+.pagination{
+  // display: flex;
+  margin-top: 50px;
+  // width: 50%;
+  text-align: center;
+  justify-content: flex-start;
+  font-size: 18px;
+}
+.pagination span{
+  background-color: white;
+  text-align: center;
+  width: 100px;
+  border: solid 1px #344963;
+  color: rgb(197, 20, 159);
+}
+.pagination span:hover{
+  transition: .3s;
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1);
+}
+.pagination span a:hover{
+  transition: .3s;
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1);
+}
+
+.pagination .current { 
+  background: #777;
+}
+

--- a/app/assets/stylesheets/shared/_posts-box.scss
+++ b/app/assets/stylesheets/shared/_posts-box.scss
@@ -3,9 +3,11 @@
 }
 
 .posts__list {
+  height: 1215px;
   padding: 0 20px;
   display: flex;
   flex-wrap: wrap;
+
 
   &__box {
     @include product-box;
@@ -48,6 +50,13 @@
       padding: 0 25px;
     }
   }
+}
+
+// ユーザー詳細ページ
+.posts__list2 {
+  padding: 0 20px;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@ class PostsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @posts = Post.includes(:user).order('created_at DESC')
+    @posts = Post.includes(:user).order('created_at DESC').page(params[:page]).per(9)
     @all_ranks = Post.find(Like.group(:post_id).order('count(post_id) desc').limit(5).pluck(:post_id))
   end
 
@@ -29,7 +29,7 @@ class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
     @user = User.find_by(id: @post.user_id)
-    @posts = @user.posts.page(params[:page]).order('created_at DESC')
+    @posts = @user.posts.page(params[:page]).order('created_at DESC').limit(5)
     @comments = @post.comments.includes(:user)
     @comment = Comment.new 
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,8 +5,8 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    @posts = @user.posts.page(params[:page]).order('created_at DESC')
-    @liked_posts = @user.liked_posts.page(params[:page]).order('created_at DESC')
+    @posts = @user.posts.page(params[:page]).order('created_at DESC').page(params[:page]).per(9)
+    @liked_posts = @user.liked_posts.page(params[:page]).order('created_at DESC').page(params[:page]).per(9)
   end
 
   # def set_user

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,9 @@
+-#  Link to the "First" page
+-#  available local variables
+-#    url:           url to the first page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.first
+  = link_to_unless current_page.first?, t('views.pagination.最初').html_safe, url, remote: remote

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,8 @@
+-#  Non-link tag that stands for skipped pages...
+-#  available local variables
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.page.gap
+  = t('views.pagination.truncate').html_safe

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,9 @@
+-#  Link to the "Last" page
+-#  available local variables
+-#    url:           url to the last page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.last
+  = link_to_unless current_page.last?, t('views.pagination.最後').html_safe, url, remote: remote

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,9 @@
+-#  Link to the "Next" page
+-#  available local variables
+-#    url:           url to the next page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.next
+  = link_to_unless current_page.last?, t('views.pagination.次').html_safe, url, rel: 'next', remote: remote

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,10 @@
+-#  Link showing page number
+-#  available local variables
+-#    page:          a page object for "this" page
+-#    url:           url to this page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span{class: "page#{' current' if page.current?}"}
+  = link_to_unless page.current?, page, url, {remote: remote, rel: page.rel}

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,18 @@
+-#  The container tag
+-#  available local variables
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+-#    paginator:     the paginator that renders the pagination tags inside
+= paginator.render do
+  %nav.pagination
+    = first_page_tag unless current_page.first?
+    = prev_page_tag unless current_page.first?
+    - each_page do |page|
+      - if page.display_tag?
+        = page_tag page
+      - elsif !page.was_truncated?
+        = gap_tag
+    = next_page_tag unless current_page.last?
+    = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,9 @@
+-#  Link to the "Previous" page
+-#  available local variables
+-#    url:           url to the previous page
+-#    current_page:  a page object for the currently displayed page
+-#    total_pages:   total number of pages
+-#    per_page:      number of items to fetch per page
+-#    remote:        data-remote
+%span.prev
+  = link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -2,3 +2,4 @@
 .posts
   %h2投稿一覧
   = render partial: "shared/posts-box", locals: { posts: @posts}
+  = paginate(@posts)

--- a/app/views/shared/_posts-box2.html.haml
+++ b/app/views/shared/_posts-box2.html.haml
@@ -1,4 +1,4 @@
-.posts__list
+.posts__list2
   - posts.each do |post|
     %div{id: "box-number#{post.id}", class: "posts__list__box"}
       = link_to post_path(post.id) do

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -15,9 +15,10 @@
     いいね一覧
 .tab-contents-box
   .tab-contents.js-tab-contents.is-show
-    = render partial: "shared/posts-box", locals: { posts: @posts}
+    = render partial: "shared/posts-box2", locals: { posts: @posts}
   .tab-contents.js-tab-contents
-    = render partial: "shared/posts-box", locals: { posts: @liked_posts}
+    = render partial: "shared/posts-box2", locals: { posts: @liked_posts}
+  = paginate(@posts)
 
 :javascript
   $(function(){


### PR DESCRIPTION
# What
1ページあたり、投稿したアイテムを最大表示9個とし、10個目以降はページ送りとした。

# Why
ぺージネーションを行うことで1ページあたりの読み込み速度が向上し、ユーザーにとっての利便性の向上に繋がるため。